### PR TITLE
Update start.sh to work if using binary 'node'

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -23,7 +23,7 @@ function startf(){
         if [ -z "$PID" ]; then
             echo "Cleaning up empty PID file $PIDFILE" >&2
             rm -f $PIDFILE
-        elif pmap "$PID" | grep -q nodejs; then
+        elif pmap "$PID" | grep -q node; then
             echo "Not starting $APP, running PID $PID" >&2
             return 1
         else


### PR DESCRIPTION
Most people have nodejs aliased or symlinked to node. The binary is always named node if using nvm or any other node version manager. Hence it is a good idea to search for just the string 'node' instead of 'nodejs'.
